### PR TITLE
Refactor API endpoints to remove redundant 'api/v1' prefix

### DIFF
--- a/api/Controllers/AuthController.cs
+++ b/api/Controllers/AuthController.cs
@@ -128,7 +128,7 @@ namespace api.Controllers
             { "code", code },
             { "client_id", Environment.GetEnvironmentVariable("GOOGLE_CLIENT_ID")! },
             { "client_secret", Environment.GetEnvironmentVariable("GOOGLE_CLIENT_SECRET")! },
-            { "redirect_uri", "https://localhost:8000/api/v1/auth/login-google/callback" },
+            { "redirect_uri", "https://itribe.id.vn/api/v1/auth/login-google/callback" },
             { "grant_type", "authorization_code" }
         })
             };

--- a/api/Pages/Admin/Categories/Create.cshtml.cs
+++ b/api/Pages/Admin/Categories/Create.cshtml.cs
@@ -26,7 +26,7 @@ namespace api.Pages.Admin.Categories
         }
         public async Task<IActionResult> OnGetAsync()
         {
-            var catRes = await _httpClient.GetAsync("api/v1/admin/categories");
+            var catRes = await _httpClient.GetAsync("v1/admin/categories");
             if (catRes.IsSuccessStatusCode)
             {
                 var catJson = await catRes.Content.ReadAsStringAsync();
@@ -44,7 +44,7 @@ namespace api.Pages.Admin.Categories
                 _httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
             }
 
-            var response = await _httpClient.PostAsJsonAsync("api/v1/admin/categories", Category);
+            var response = await _httpClient.PostAsJsonAsync("v1/admin/categories", Category);
             if (response.IsSuccessStatusCode)
             {
                 var json = await response.Content.ReadAsStringAsync();

--- a/api/Pages/Admin/Categories/Delete.cshtml.cs
+++ b/api/Pages/Admin/Categories/Delete.cshtml.cs
@@ -56,7 +56,7 @@ namespace api.Pages.Admin.Categories
             {
                 _httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
             }
-            var response = await _httpClient.DeleteAsync($"api/v1/admin/categories/{Id}");
+            var response = await _httpClient.DeleteAsync($"v1/admin/categories/{Id}");
             if (response.IsSuccessStatusCode)
             {
                 return RedirectToPage("./Index");

--- a/api/Pages/Admin/Categories/Index.cshtml.cs
+++ b/api/Pages/Admin/Categories/Index.cshtml.cs
@@ -36,7 +36,7 @@ namespace api.Pages.Admin.Categories
                 _httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
             }
             // Lấy danh mục cha
-            var parentResponse = await _httpClient.GetAsync("api/v1/admin/categories");
+            var parentResponse = await _httpClient.GetAsync("v1/admin/categories");
             if (parentResponse.IsSuccessStatusCode)
             {
                 var json = await parentResponse.Content.ReadAsStringAsync();
@@ -47,7 +47,7 @@ namespace api.Pages.Admin.Categories
                 // Lấy children cho từng parent
                 foreach (var parent in Parents)
                 {
-                    var subResponse = await _httpClient.GetAsync($"api/v1/admin/categories/sub/{parent._id}");
+                    var subResponse = await _httpClient.GetAsync($"v1/admin/categories/sub/{parent._id}");
                     if (subResponse.IsSuccessStatusCode)
                     {
                         var subJson = await subResponse.Content.ReadAsStringAsync();

--- a/api/Pages/Admin/Categories/Update.cshtml.cs
+++ b/api/Pages/Admin/Categories/Update.cshtml.cs
@@ -91,7 +91,7 @@ namespace api.Pages.Admin.Categories
                 Category.parent_category = null;
             }
 
-            var response = await _httpClient.PutAsJsonAsync($"api/v1/admin/categories/{Id}", Category);
+            var response = await _httpClient.PutAsJsonAsync($"v1/admin/categories/{Id}", Category);
             if (response.IsSuccessStatusCode)
             {
                 return RedirectToPage("/Admin/Categories/Index");
@@ -111,7 +111,7 @@ namespace api.Pages.Admin.Categories
             if (string.IsNullOrEmpty(token)) return;
 
             _httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
-            var catRes = await _httpClient.GetAsync("api/v1/admin/categories");
+            var catRes = await _httpClient.GetAsync("v1/admin/categories");
             if (catRes.IsSuccessStatusCode)
             {
                 var catJson = await catRes.Content.ReadAsStringAsync();

--- a/api/Pages/Admin/Customers/Details.cshtml.cs
+++ b/api/Pages/Admin/Customers/Details.cshtml.cs
@@ -39,7 +39,7 @@ namespace api.Pages.Admin.Customers
 
             try
             {
-                var customerResponse = await _httpClient.GetAsync($"api/v1/admin/customers/{id}");
+                var customerResponse = await _httpClient.GetAsync($"v1/admin/customers/{id}");
                 if (customerResponse.IsSuccessStatusCode)
                 {
                     var customerJson = await customerResponse.Content.ReadAsStringAsync();
@@ -47,7 +47,7 @@ namespace api.Pages.Admin.Customers
                     Customer = JsonSerializer.Deserialize<User>(customerDoc.RootElement.GetProperty("data").ToString());
                 }
 
-                var pointsResponse = await _httpClient.GetAsync($"api/v1/admin/customers/{id}/points");
+                var pointsResponse = await _httpClient.GetAsync($"v1/admin/customers/{id}/points");
                 if (pointsResponse.IsSuccessStatusCode)
                 {
                     var pointsJson = await pointsResponse.Content.ReadAsStringAsync();
@@ -55,7 +55,7 @@ namespace api.Pages.Admin.Customers
                     CustomerPoints = JsonSerializer.Deserialize<GetCustomerPointDto>(pointsDoc.RootElement.GetProperty("data").ToString());
                 }
 
-                var vouchersResponse = await _httpClient.GetAsync($"api/v1/admin/customers/{id}/vouchers");
+                var vouchersResponse = await _httpClient.GetAsync($"v1/admin/customers/{id}/vouchers");
                 if (vouchersResponse.IsSuccessStatusCode)
                 {
                     var vouchersJson = await vouchersResponse.Content.ReadAsStringAsync();

--- a/api/Pages/Admin/Dashboard/Index.cshtml.cs
+++ b/api/Pages/Admin/Dashboard/Index.cshtml.cs
@@ -41,12 +41,12 @@ namespace api.Pages.Admin.Dashboard
             if (!string.IsNullOrEmpty(accessToken))
                 http.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", accessToken);
 
-            Summary = await http.GetFromJsonAsync<TotalDto>($"/api/v1/revenue/total?fromDate={FromDate:yyyy-MM-dd}&toDate={ToDate:yyyy-MM-dd}");
+            Summary = await http.GetFromJsonAsync<TotalDto>($"/v1/revenue/total?fromDate={FromDate:yyyy-MM-dd}&toDate={ToDate:yyyy-MM-dd}");
 
-            ChartData = await http.GetFromJsonAsync<ChartResponseDto>($"/api/v1/revenue/chart?fromDate={FromDate:yyyy-MM-dd}&toDate={ToDate:yyyy-MM-dd}");
+            ChartData = await http.GetFromJsonAsync<ChartResponseDto>($"/v1/revenue/chart?fromDate={FromDate:yyyy-MM-dd}&toDate={ToDate:yyyy-MM-dd}");
 
-            TopProducts = await http.GetFromJsonAsync<List<TopProductDtoRes>>($"/api/v1/revenue/top10?fromDate={FromDate:yyyy-MM-dd}&toDate={ToDate:yyyy-MM-dd}");
-            TopLocations = await http.GetFromJsonAsync<List<TopLocationDto>>($"/api/v1/revenue/top-sales-by-location?fromDate={FromDate:yyyy-MM-dd}&toDate={ToDate:yyyy-MM-dd}");
+            TopProducts = await http.GetFromJsonAsync<List<TopProductDtoRes>>($"/v1/revenue/top10?fromDate={FromDate:yyyy-MM-dd}&toDate={ToDate:yyyy-MM-dd}");
+            TopLocations = await http.GetFromJsonAsync<List<TopLocationDto>>($"/v1/revenue/top-sales-by-location?fromDate={FromDate:yyyy-MM-dd}&toDate={ToDate:yyyy-MM-dd}");
         }
 
         // Update AJAX endpoint for chart to get fromDate and toDate
@@ -59,7 +59,7 @@ namespace api.Pages.Admin.Dashboard
             if (!string.IsNullOrEmpty(accessToken))
                 http.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", accessToken);
 
-            var chartResponse = await http.GetFromJsonAsync<ChartResponseDto>($"/api/v1/revenue/chart?fromDate={fromDate:yyyy-MM-dd}&toDate={toDate:yyyy-MM-dd}");
+            var chartResponse = await http.GetFromJsonAsync<ChartResponseDto>($"/v1/revenue/chart?fromDate={fromDate:yyyy-MM-dd}&toDate={toDate:yyyy-MM-dd}");
             return new JsonResult(chartResponse); // Return alls response object
         }
 

--- a/api/Pages/Admin/Index.cshtml.cs
+++ b/api/Pages/Admin/Index.cshtml.cs
@@ -58,7 +58,7 @@ namespace api.Pages.Admin
                     role = "admin"
                 };
 
-                var response = await _httpClient.PostAsJsonAsync("/api/v1/auth/login", loginDto);
+                var response = await _httpClient.PostAsJsonAsync("/v1/auth/login", loginDto);
                 var responseContent = await response.Content.ReadAsStringAsync();
 
                 if (response.IsSuccessStatusCode)

--- a/api/Pages/Admin/Logout.cshtml.cs
+++ b/api/Pages/Admin/Logout.cshtml.cs
@@ -24,7 +24,7 @@ namespace api.Pages.Admin
                 var refreshToken = Request.Cookies["refreshToken"];
                 if (!string.IsNullOrEmpty(refreshToken))
                 {
-                    await _httpClient.PostAsync($"/api/v1/auth/logout", null);
+                    await _httpClient.PostAsync($"/v1/auth/logout", null);
                 }
                 return RedirectToPage("/Admin/Index");
             }

--- a/api/Pages/Admin/Orders/Details.cshtml.cs
+++ b/api/Pages/Admin/Orders/Details.cshtml.cs
@@ -35,7 +35,7 @@ namespace api.Pages.Admin.Orders
             {
                 _httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
             }
-            var url = $"api/v1/admin/orders/{id}";
+            var url = $"v1/admin/orders/{id}";
             var response = await _httpClient.GetAsync(url);
             if (response.IsSuccessStatusCode)
             {
@@ -67,7 +67,7 @@ namespace api.Pages.Admin.Orders
                 _httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
             }
 
-            var updateUrl = $"api/v1/admin/orders/{id}";
+            var updateUrl = $"v1/admin/orders/{id}";
             var payload = new { status = SelectedStatus };
             var content = new StringContent(JsonSerializer.Serialize(payload), System.Text.Encoding.UTF8, "application/json");
             var updateResponse = await _httpClient.PutAsync(updateUrl, content);

--- a/api/Pages/Admin/Orders/Index.cshtml.cs
+++ b/api/Pages/Admin/Orders/Index.cshtml.cs
@@ -55,7 +55,7 @@ namespace api.Pages.Admin.Orders
             {
                 _httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
             }
-            var url = $"api/v1/admin/orders?page={CurrentPage}&size={SizeOrder}";
+            var url = $"v1/admin/orders?page={CurrentPage}&size={SizeOrder}";
 
             if (!string.IsNullOrEmpty(OrderId)) url += $"&orderId={OrderId}";
             if (!string.IsNullOrEmpty(Customer)) url += $"&customer={Customer}";

--- a/api/Pages/Admin/Products/Create.cshtml.cs
+++ b/api/Pages/Admin/Products/Create.cshtml.cs
@@ -20,7 +20,7 @@ namespace api.Pages.Admin.Products
         }
         public async Task<IActionResult> OnGetAsync()
         {
-            var catRes = await _httpClient.GetAsync("api/v1/admin/categories");
+            var catRes = await _httpClient.GetAsync("v1/admin/categories");
             if (catRes.IsSuccessStatusCode)
             {
                 var catJson = await catRes.Content.ReadAsStringAsync();
@@ -38,7 +38,7 @@ namespace api.Pages.Admin.Products
                 _httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
             }
 
-            var response = await _httpClient.PostAsJsonAsync("api/v1/admin/products", Product);
+            var response = await _httpClient.PostAsJsonAsync("v1/admin/products", Product);
             if (response.IsSuccessStatusCode)
             {
                 var json = await response.Content.ReadAsStringAsync();

--- a/api/Pages/Admin/Products/Delete.cshtml.cs
+++ b/api/Pages/Admin/Products/Delete.cshtml.cs
@@ -28,7 +28,7 @@ namespace api.Pages.Admin.Products
             {
                 _httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
             }
-            var response = await _httpClient.GetAsync($"api/v1/admin/products/{Id}");
+            var response = await _httpClient.GetAsync($"v1/admin/products/{Id}");
             if (!response.IsSuccessStatusCode) return RedirectToPage("./Index");
 
             var json = await response.Content.ReadAsStringAsync();
@@ -44,7 +44,7 @@ namespace api.Pages.Admin.Products
             {
                 _httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
             }
-            var response = await _httpClient.DeleteAsync($"api/v1/admin/products/{Id}");
+            var response = await _httpClient.DeleteAsync($"v1/admin/products/{Id}");
             return response.IsSuccessStatusCode ? RedirectToPage("./Index") : Page();
         }
     }

--- a/api/Pages/Admin/Products/Details.cshtml.cs
+++ b/api/Pages/Admin/Products/Details.cshtml.cs
@@ -32,7 +32,7 @@ namespace api.Pages.Admin.Products
             {
                 _httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
             }
-            var response = await _httpClient.GetAsync($"api/v1/admin/products/{id}");
+            var response = await _httpClient.GetAsync($"v1/admin/products/{id}");
             if (!response.IsSuccessStatusCode) return RedirectToPage("./Index");
             var json = await response.Content.ReadAsStringAsync();
             var result = JsonDocument.Parse(json);

--- a/api/Pages/Admin/Products/Edit.cshtml.cs
+++ b/api/Pages/Admin/Products/Edit.cshtml.cs
@@ -34,7 +34,7 @@ namespace api.Pages.Admin.Products
             {
                 _httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
             }
-            var response = await _httpClient.GetAsync($"api/v1/admin/products/{Id}");
+            var response = await _httpClient.GetAsync($"v1/admin/products/{Id}");
             if (!response.IsSuccessStatusCode) return RedirectToPage("./Index");
 
             var json = await response.Content.ReadAsStringAsync();
@@ -46,7 +46,7 @@ namespace api.Pages.Admin.Products
                 description = Product.description,
                 category = Product.category._id
             };
-            var catRes = await _httpClient.GetAsync("api/v1/admin/categories");
+            var catRes = await _httpClient.GetAsync("v1/admin/categories");
             if (catRes.IsSuccessStatusCode)
             {
                 var catJson = await catRes.Content.ReadAsStringAsync();
@@ -64,7 +64,7 @@ namespace api.Pages.Admin.Products
                 _httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
             }
 
-            var response = await _httpClient.PutAsJsonAsync($"api/v1/admin/products/{Id}", UpdateProduct);
+            var response = await _httpClient.PutAsJsonAsync($"v1/admin/products/{Id}", UpdateProduct);
             return response.IsSuccessStatusCode ? RedirectToPage("./Index") : Page();
         }
     }

--- a/api/Pages/Admin/Products/Index.cshtml.cs
+++ b/api/Pages/Admin/Products/Index.cshtml.cs
@@ -40,7 +40,7 @@ namespace api.Pages.Admin.Products
             {
                 _httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
             }
-            var catRes = await _httpClient.GetAsync("api/v1/admin/categories");
+            var catRes = await _httpClient.GetAsync("v1/admin/categories");
             if (catRes.IsSuccessStatusCode)
             {
                 var catJson = await catRes.Content.ReadAsStringAsync();
@@ -53,7 +53,7 @@ namespace api.Pages.Admin.Products
             MaxPrice = maxPrice;
             Color = color;
             Storage = storage;
-            var url = $"api/v1/admin/products/search?page={page}&size={size}";
+            var url = $"v1/admin/products/search?page={page}&size={size}";
             if (!string.IsNullOrEmpty(search)) url += $"&search={Uri.EscapeDataString(search)}";
             if (!string.IsNullOrEmpty(categoryId)) url += $"&categoryId={Uri.EscapeDataString(categoryId)}";
             if (minPrice.HasValue) url += $"&minPrice={minPrice.Value}";

--- a/api/Pages/Admin/Variants/Create.cshtml.cs
+++ b/api/Pages/Admin/Variants/Create.cshtml.cs
@@ -38,7 +38,7 @@ namespace api.Pages.Admin.Variants
                 {
                     _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
                 }
-                var response = await _httpClient.GetAsync($"api/v1/admin/products/{productId}");
+                var response = await _httpClient.GetAsync($"v1/admin/products/{productId}");
                 if (response.IsSuccessStatusCode)
                 {
                     var json = await response.Content.ReadAsStringAsync();
@@ -77,7 +77,7 @@ namespace api.Pages.Admin.Variants
                     form.Add(streamContent, "images", file.FileName);
                 }
             }
-            var response = await _httpClient.PostAsync($"api/v1/admin/products/variant", form);
+            var response = await _httpClient.PostAsync($"v1/admin/products/variant", form);
             var responseContent = await response.Content.ReadAsStringAsync();
             if (!response.IsSuccessStatusCode)
             {

--- a/api/Pages/Admin/Variants/Delete.cshtml.cs
+++ b/api/Pages/Admin/Variants/Delete.cshtml.cs
@@ -34,7 +34,7 @@ namespace api.Pages.Admin.Variants
             {
                 _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
             }
-            var response = await _httpClient.GetAsync($"api/v1/admin/products/variant/{id}");
+            var response = await _httpClient.GetAsync($"v1/admin/products/variant/{id}");
             if (response.IsSuccessStatusCode)
             {
                 var json = await response.Content.ReadAsStringAsync();
@@ -54,7 +54,7 @@ namespace api.Pages.Admin.Variants
             {
                 _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
             }
-            var response = await _httpClient.DeleteAsync($"api/v1/admin/products/variant/{id}");
+            var response = await _httpClient.DeleteAsync($"v1/admin/products/variant/{id}");
             var responseContent = await response.Content.ReadAsStringAsync();
             if (!response.IsSuccessStatusCode)
             {

--- a/api/Pages/Admin/Variants/Edit.cshtml.cs
+++ b/api/Pages/Admin/Variants/Edit.cshtml.cs
@@ -47,7 +47,7 @@ namespace api.Pages.Admin.Variants
             {
                 _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
             }
-            var response = await _httpClient.GetAsync($"api/v1/admin/products/variant/{id}");
+            var response = await _httpClient.GetAsync($"v1/admin/products/variant/{id}");
             if (response.IsSuccessStatusCode)
             {
                 var json = await response.Content.ReadAsStringAsync();
@@ -67,7 +67,7 @@ namespace api.Pages.Admin.Variants
                         EditVariant.slug = variant.slug;
                         EditVariant.existingImages = variant.images ?? new List<string>();
                         // Lấy product name từ API
-                        var productResponse = await _httpClient.GetAsync($"api/v1/admin/products/{variant.product}");
+                        var productResponse = await _httpClient.GetAsync($"v1/admin/products/{variant.product}");
                         if (productResponse.IsSuccessStatusCode)
                         {
                             var productJson = await productResponse.Content.ReadAsStringAsync();
@@ -121,7 +121,7 @@ namespace api.Pages.Admin.Variants
                     form.Add(streamContent, "images", file.FileName);
                 }
             }
-            var response = await _httpClient.PutAsync($"api/v1/admin/products/variant/{EditVariant.variantId}", form);
+            var response = await _httpClient.PutAsync($"v1/admin/products/variant/{EditVariant.variantId}", form);
             var responseContent = await response.Content.ReadAsStringAsync();
             if (!response.IsSuccessStatusCode)
             {

--- a/api/Pages/Shared/_Layout.cshtml
+++ b/api/Pages/Shared/_Layout.cshtml
@@ -159,7 +159,7 @@
 
         async function fetchNotifications() {
             try {
-                const response = await fetch('/api/v1/notifications', {
+                const response = await fetch('/v1/notifications', {
                     method: 'GET',
                     headers: {
                         'Content-Type': 'application/json',
@@ -293,7 +293,7 @@
 
         async function markAsRead(notificationId) {
             try {
-                const response = await fetch(`/api/v1/notifications/${notificationId}/read`, {
+                const response = await fetch(`/v1/notifications/${notificationId}/read`, {
                     method: 'PUT',
                     headers: {
                         'Content-Type': 'application/json',

--- a/api/Repositories/Customer/PaymentRepository.cs
+++ b/api/Repositories/Customer/PaymentRepository.cs
@@ -105,7 +105,7 @@ namespace api.Repositories.Customer
             var secretKey = Environment.GetEnvironmentVariable("MOMO_SECRET_KEY");
             var partnerCode = Environment.GetEnvironmentVariable("MOMO_PARTNER_CODE");
             var redirectUrl = Environment.GetEnvironmentVariable("CLIENT_URL") + "/payment/success";
-            var callbackUrl = Environment.GetEnvironmentVariable("SERVER_URL") + "/api/v1/payment/momo/callback";
+            var callbackUrl = Environment.GetEnvironmentVariable("SERVER_URL") + "/v1/payment/momo/callback";
 
             var infoPayment = $"Thanh toán đơn hàng {dto.orderId}";
             var voucherCode = await _redisRepository.GetAsync($"voucher-{dto.orderId}");
@@ -135,7 +135,7 @@ namespace api.Repositories.Customer
             var client = _httpClientFactory.CreateClient();
             var httpContent = new StringContent(JsonSerializer.Serialize(requestBody), Encoding.UTF8, "application/json");
 
-            var response = await client.PostAsync("https://test-payment.momo.vn/v2/gateway/api/create", httpContent);
+            var response = await client.PostAsync("https://test-payment.momo.vn/v2/gateway/create", httpContent);
             var json = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
 
             var resultCode = json.RootElement.GetProperty("resultCode").GetInt32();

--- a/frontend/src/app/(auth)/login/login-form.tsx
+++ b/frontend/src/app/(auth)/login/login-form.tsx
@@ -202,7 +202,7 @@ export default function LoginForm() {
         variant="outline"
         type="button"
         onClick={() =>
-          (window.location.href = `${process.env.NEXT_PUBLIC_API_ENDPOINT}/api/v1/auth/login-google`)
+          (window.location.href = `${process.env.NEXT_PUBLIC_API_ENDPOINT}/v1/auth/login-google`)
         }
         className="w-full font-sans text-gray-500"
       >

--- a/frontend/src/app/(auth)/register/register-form.tsx
+++ b/frontend/src/app/(auth)/register/register-form.tsx
@@ -236,7 +236,7 @@ export default function RegisterForm() {
           type="button"
           variant="outline"
           onClick={() =>
-            (window.location.href = `${process.env.NEXT_PUBLIC_API_ENDPOINT}/api/v1/auth/login-google?returnUrl=${process.env.NEXT_PUBLIC_CLIENT_ENDPOINT}`)
+            (window.location.href = `${process.env.NEXT_PUBLIC_API_ENDPOINT}/v1/auth/login-google?returnUrl=${process.env.NEXT_PUBLIC_CLIENT_ENDPOINT}`)
           }
           className="w-full font-sans text-gray-500"
         >

--- a/frontend/src/services/auth/authApi.ts
+++ b/frontend/src/services/auth/authApi.ts
@@ -11,7 +11,7 @@ import {
 
 export const login = async ({ email, password }: LoginType) => {
   return await axios.post(
-    `${process.env.NEXT_PUBLIC_API_ENDPOINT}/api/v1/auth/login`,
+    `${process.env.NEXT_PUBLIC_API_ENDPOINT}/v1/auth/login`,
     {
       email,
       password,
@@ -25,7 +25,7 @@ export const login = async ({ email, password }: LoginType) => {
 
 export const signUp = async ({ name, email, password }: SignUpType) => {
   const response = await axios.post(
-    `${process.env.NEXT_PUBLIC_API_ENDPOINT}/api/v1/auth/signup`,
+    `${process.env.NEXT_PUBLIC_API_ENDPOINT}/v1/auth/signup`,
     {
       name,
       email,
@@ -37,7 +37,7 @@ export const signUp = async ({ name, email, password }: SignUpType) => {
 
 export const verifySignUp = async ({ email, otp }: VerifySignUpType) => {
   const response = await axios.post(
-    `${process.env.NEXT_PUBLIC_API_ENDPOINT}/api/v1/auth/verify-signup`,
+    `${process.env.NEXT_PUBLIC_API_ENDPOINT}/v1/auth/verify-signup`,
     {
       email,
       otp,
@@ -47,17 +47,17 @@ export const verifySignUp = async ({ email, otp }: VerifySignUpType) => {
 };
 
 export const logout = async () => {
-  const response = await axiosInstance.post(`/api/v1/auth/logout`);
+  const response = await axiosInstance.post(`/v1/auth/logout`);
   return response;
 };
 
 export const resentOTP = async (email: string) => {
-  return await axiosInstance.post(`/api/v1/auth/resent-otp`, { email });
+  return await axiosInstance.post(`/v1/auth/resent-otp`, { email });
 };
 
 export const getProfile = async (): Promise<ProfileType> => {
   const response = await axiosInstance.get<IResponseProfileType>(
-    "/api/v1/auth/profile"
+    "/v1/auth/profile"
   );
   return response.data.data;
 };
@@ -77,7 +77,7 @@ export const updateProfile = async ({
   };
   phoneNumber: string;
 }) => {
-  return await axiosInstance.put(`/api/v1/auth/update-profile`, {
+  return await axiosInstance.put(`/v1/auth/update-profile`, {
     name,
     address,
     phoneNumber,
@@ -86,21 +86,21 @@ export const updateProfile = async ({
 
 export const forgotPassword = async (email: string) => {
   return await axios.post(
-    `${process.env.NEXT_PUBLIC_API_ENDPOINT}/api/v1/auth/forgot-password`,
+    `${process.env.NEXT_PUBLIC_API_ENDPOINT}/v1/auth/forgot-password`,
     { email }
   );
 };
 
 export const resetPassword = async (token: string, password: string) => {
   return await axios.post(
-    `${process.env.NEXT_PUBLIC_API_ENDPOINT}/api/v1/auth/reset-password/${token}`,
+    `${process.env.NEXT_PUBLIC_API_ENDPOINT}/v1/auth/reset-password/${token}`,
     { password }
   );
 };
 
 export const refreshToken = async () => {
   const response = await axiosInstance.post(
-    `${process.env.NEXT_PUBLIC_API_ENDPOINT}/api/v1/auth/refresh-token`,
+    `${process.env.NEXT_PUBLIC_API_ENDPOINT}/v1/auth/refresh-token`,
     { withCredentials: true }
   );
   return response;

--- a/frontend/src/services/categories/categoriesApi.ts
+++ b/frontend/src/services/categories/categoriesApi.ts
@@ -3,14 +3,14 @@ import { Category } from "@/types/category";
 
 export const getCategories = async (): Promise<Category[]> => {
   const res = await axiosInstance.get<{ data: Category[] }>(
-    `/api/v1/admin/categories/`
+    `/v1/admin/categories/`
   );
   return res.data.data.filter((category) => !category.parent_category);
 };
 
 export const getSubCategories = async (parentCategoryId: string) => {
   const res = await axiosInstance.get(
-    `/api/v1/admin/categories/sub/${parentCategoryId}`
+    `/v1/admin/categories/sub/${parentCategoryId}`
   );
   return res.data;
 };

--- a/frontend/src/services/chatbot/chatbotApi.ts
+++ b/frontend/src/services/chatbot/chatbotApi.ts
@@ -12,12 +12,12 @@ export interface ChatHistory {
 }
 
 export const createChatSession = async () => {
-  const response = await axiosInstance.post("/api/v1/chatbot/session");
+  const response = await axiosInstance.post("/v1/chatbot/session");
   return response.data;
 };
 
 export const sendMessage = async (sessionId: string, message: string) => {
-  const response = await axiosInstance.post("/api/v1/chatbot/message", {
+  const response = await axiosInstance.post("/v1/chatbot/message", {
     sessionId,
     message,
   });
@@ -25,6 +25,6 @@ export const sendMessage = async (sessionId: string, message: string) => {
 };
 
 export const getChatHistory = async (sessionId: string) => {
-  const response = await axiosInstance.get(`/api/v1/chatbot/history/${sessionId}`);
+  const response = await axiosInstance.get(`/v1/chatbot/history/${sessionId}`);
   return response.data;
 }; 

--- a/frontend/src/services/notifications/notificationApi.ts
+++ b/frontend/src/services/notifications/notificationApi.ts
@@ -7,7 +7,7 @@ import {
 export const getNotifications = async (
   type: string = "all"
 ): Promise<IResponseNotification> => {
-  const res = await axiosInstance.get(`/api/v1/notifications?type=${type}`);
+  const res = await axiosInstance.get(`/v1/notifications?type=${type}`);
   return res.data;
 };
 
@@ -15,7 +15,7 @@ export const maskNotificationAsRead = async (
   notificationId: string
 ): Promise<IResponseMarkAsRead> => {
   const res = await axiosInstance.put(
-    `/api/v1/notifications/${notificationId}/read`
+    `/v1/notifications/${notificationId}/read`
   );
   return res.data;
 };

--- a/frontend/src/services/orders/orderApi.ts
+++ b/frontend/src/services/orders/orderApi.ts
@@ -2,14 +2,14 @@ import { axiosInstance } from "@/config/axiosInstance";
 import { OrderType, Orders } from "@/types/order";
 
 export const createOrder = async (checkoutData: OrderType) => {
-  return await axiosInstance.post(`/api/v1/orders/`, checkoutData);
+  return await axiosInstance.post(`/v1/orders/`, checkoutData);
 };
 
 export const cancelOrder = async (orderId: string) => {
-  return await axiosInstance.put(`/api/v1/orders/${orderId}`);
+  return await axiosInstance.put(`/v1/orders/${orderId}`);
 };
 
 export const getOrders = async (): Promise<Orders> => {
-  const res = await axiosInstance.get(`/api/v1/orders/`);
+  const res = await axiosInstance.get(`/v1/orders/`);
   return res.data;
 };

--- a/frontend/src/services/payment/paymentApi.ts
+++ b/frontend/src/services/payment/paymentApi.ts
@@ -5,7 +5,7 @@ export const createCheckoutSession = async ({
   variants,
   orderId,
 }: PaymentType) => {
-  return await axiosInstance.post("/api/v1/payment/create-checkout-session", {
+  return await axiosInstance.post("/v1/payment/create-checkout-session", {
     variants,
     orderId,
   });
@@ -18,7 +18,7 @@ export const updateOrderPayment = async ({
   stripeSessionId: string;
   orderId: string;
 }) => {
-  return await axiosInstance.post("/api/v1/orders/update-order-payment", {
+  return await axiosInstance.post("/v1/orders/update-order-payment", {
     stripeSessionId,
     orderId,
   });
@@ -30,14 +30,14 @@ export const createMomoPayment = async (data: {
   orderInfo: string;
 }) => {
   const response = await axiosInstance.post(
-    `/api/v1/payment/momo/create`,
+    `/v1/payment/momo/create`,
     data
   );
   return response;
 };
 
 export const momoCallback = async (data: IMomoCallback) => {
-  const response = await axiosInstance.post('/api/v1/payment/momo/callback', data);
+  const response = await axiosInstance.post('/v1/payment/momo/callback', data);
   return response;
 }
 

--- a/frontend/src/services/products/productsApi.ts
+++ b/frontend/src/services/products/productsApi.ts
@@ -2,20 +2,20 @@ import axios from "axios";
 
 export const getProductsByCategory = async (categoryId: string) => {
   const res = await axios.get(
-    `${process.env.NEXT_PUBLIC_API_ENDPOINT}/api/v1/products/filter?categoryId=${categoryId}`
+    `${process.env.NEXT_PUBLIC_API_ENDPOINT}/v1/products/filter?categoryId=${categoryId}`
   );
   return res.data;
 };
 
 export const getProducts = async () => {
   return await axios.get(
-    `${process.env.NEXT_PUBLIC_API_ENDPOINT}/api/v1/products/`
+    `${process.env.NEXT_PUBLIC_API_ENDPOINT}/v1/products/`
   );
 };
 
 export const getProductBySlug = async (slug: string) => {
   const res = await axios.post(
-    `${process.env.NEXT_PUBLIC_API_ENDPOINT}/api/v1/products/`,
+    `${process.env.NEXT_PUBLIC_API_ENDPOINT}/v1/products/`,
     {
       slug,
     }

--- a/frontend/src/services/profile/profileApi.ts
+++ b/frontend/src/services/profile/profileApi.ts
@@ -3,20 +3,20 @@ import { IDistrictType, IProvinceType, IWardType } from "@/types/profile";
 
 export const getProvinces = async () => {
   const res = await axiosInstance.get<IProvinceType[]>(
-    `${process.env.NEXT_PUBLIC_API_ENDPOINT}/api/v1/provinces`
+    `${process.env.NEXT_PUBLIC_API_ENDPOINT}/v1/provinces`
   );
   return res.data;
 };
 export const getDistricts = async (code: number) => {
   const res = await axiosInstance.get<IDistrictType[]>(
-    `${process.env.NEXT_PUBLIC_API_ENDPOINT}/api/v1/districts/${code}`
+    `${process.env.NEXT_PUBLIC_API_ENDPOINT}/v1/districts/${code}`
   );
   return res.data;
 };
 
 export const getWards = async (code: number) => {
   const res = await axiosInstance.get<IWardType[]>(
-    `${process.env.NEXT_PUBLIC_API_ENDPOINT}/api/v1/wards/${code}`
+    `${process.env.NEXT_PUBLIC_API_ENDPOINT}/v1/wards/${code}`
   );
   return res.data;
 };

--- a/frontend/src/services/promotions/promotionApi.ts
+++ b/frontend/src/services/promotions/promotionApi.ts
@@ -6,26 +6,26 @@ import {
 } from "@/types/promotion";
 
 export const retrievePoints = async (): Promise<IResponsePoints> => {
-  const res = await axiosInstance.get("/api/v1/points/");
+  const res = await axiosInstance.get("/v1/points/");
   return res.data;
 };
 
 export const exchangeVoucher = async (
   pointsToUse: number
 ): Promise<IResponseExchangeVoucher> => {
-  const res = await axiosInstance.post("/api/v1/points/exchange-voucher", {
+  const res = await axiosInstance.post("/v1/points/exchange-voucher", {
     pointsToUse,
   });
   return res.data;
 };
 
 export const getVouchers = async (): Promise<IResponseVoucherList> => {
-  const res = await axiosInstance.get("/api/v1/points/vouchers");
+  const res = await axiosInstance.get("/v1/points/vouchers");
   return res.data;
 };
 
 export const applyVoucher = async (voucherCode: string, orderTotal: number) => {
-  const res = await axiosInstance.post("/api/v1/points/apply-voucher", {
+  const res = await axiosInstance.post("/v1/points/apply-voucher", {
     voucherCode,
     orderTotal,
   });
@@ -36,7 +36,7 @@ export const updateVoucherAsUsed = async (
   voucherCode: string,
   orderId: string
 ) => {
-  const res = await axiosInstance.put("/api/v1/points/status-voucher", {
+  const res = await axiosInstance.put("/v1/points/status-voucher", {
     voucherCode,
     orderId,
   });

--- a/frontend/src/services/review/reviewApi.ts
+++ b/frontend/src/services/review/reviewApi.ts
@@ -10,7 +10,7 @@ export const createReview = async ({
   rating: number;
   comment: string;
 }): Promise<IResponseReview> => {
-  const res = await axiosInstance.post("/api/v1/reviews", {
+  const res = await axiosInstance.post("/v1/reviews", {
     variant,
     rating,
     comment,
@@ -30,7 +30,7 @@ export const updateReview = async (
     comment?: string;
   }
 ): Promise<IResponseReview> => {
-  const res = await axiosInstance.put(`/api/v1/reviews/${id}`, {
+  const res = await axiosInstance.put(`/v1/reviews/${id}`, {
     variant,
     rating,
     comment,
@@ -38,6 +38,6 @@ export const updateReview = async (
   return res.data;
 };
 export const deleteReview = async (id: string): Promise<IResponseReview> => {
-  const res = await axiosInstance.delete(`/api/v1/reviews/${id}`);
+  const res = await axiosInstance.delete(`/v1/reviews/${id}`);
   return res.data;
 };

--- a/frontend/src/services/shipping-method/shippingApi.ts
+++ b/frontend/src/services/shipping-method/shippingApi.ts
@@ -1,7 +1,7 @@
 import { axiosInstance } from "@/config/axiosInstance";
 
 export const shippingFee = async (shippingAddress: string, weight: number, height: number, length: number, width: number) => {
-  const res = await axiosInstance.post(`/api/v1/shipping-methods/calculate-fee`, {
+  const res = await axiosInstance.post(`/v1/shipping-methods/calculate-fee`, {
     shippingAddress,
     weight,
     height,


### PR DESCRIPTION
- Updated AuthController to use new redirect URI for Google login.
- Modified various Admin category, customer, dashboard, and order pages to use simplified API endpoints.
- Adjusted product and variant management pages to reflect new endpoint structure.
- Changed notification and payment APIs to align with updated endpoint paths.
- Updated frontend services for authentication, categories, orders, payments, and reviews to use new endpoint format.